### PR TITLE
Don't output wrapper element unless content isn't immediately available

### DIFF
--- a/lib/assets/javascripts/cedar.handlebars.js
+++ b/lib/assets/javascripts/cedar.handlebars.js
@@ -40,18 +40,13 @@ Handlebars.registerHelper('cedar', function(options) {
     tagName = options.hash.tagName || "div";
   }
 
-  options.el = document.createElement(tagName);
-  options.el.id = "cedar-js-" + hashCode(options.hash.id);
+  var outputEl = document.createElement(tagName);
+  outputEl.id = "cedar-js-" + hashCode(options.hash.id);
+
+  var output = '';
 
   new Cedar.ContentEntry({ cedarId: options.hash.id }).retrieve().then(function(contentEntry){
-
-    var domEl = document.getElementById(options.el.id);
-    if (domEl === null) {
-      domEl = options.el;
-    }
-
     if (blockHelperStyle()) {
-      var output = '';
       if (Cedar.auth.isEditMode()) {
         output += contentEntry.getEditOpen();
       }
@@ -59,11 +54,16 @@ Handlebars.registerHelper('cedar', function(options) {
       if (Cedar.auth.isEditMode()) {
         output += contentEntry.getEditClose();
       }
-      domEl.innerHTML = output;
     } else {
-      domEl.innerHTML = contentEntry.getContent();
+      output = contentEntry.getContent();
+    }
+
+    // If rendered element exists than insert the content
+    var renderedEl = document.getElementById(outputEl.id);
+    if (renderedEl !== null) {
+      renderedEl.innerHTML = output;
     }
   });
 
-  return new Handlebars.SafeString(options.el.outerHTML);
+  return new Handlebars.SafeString(output || outputEl.outerHTML);
 });


### PR DESCRIPTION
http://jira.plyinc.dev/browse/CDR-57

This change makes it so that a wrapping element is not output unless the content isn't yet available. In the latter case, an empty element is still rendered and then filled in later with content.

@jedmurdock 
